### PR TITLE
Make typing conditional on python version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-typing
+typing; python_version < '3.5'

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def readme():
         return f.read()
 
 
-dependencies = ['typing']
+dependencies = ["typing; python_version < '3.5'"]
 
 setup(
     name='circuitbreaker',


### PR DESCRIPTION
Address #8 so that the native `typing` module can be used in python 3.