### PR TITLE
Adding support for generator functions and coroutines

### DIFF
--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -47,23 +47,27 @@ def test_circuitbreaker_should_clear_last_exception_on_success_call():
 def test_circuitbreaker_should_call_fallback_function_if_open():
     fallback = Mock(return_value=True)
 
-    func = Mock(return_value=False)
+    func = Mock(return_value=False, __name__="Mock") # attribute __name__ required for 2.7 compat with functools.wraps
 
     CircuitBreaker.opened = lambda self: True
     
     cb = CircuitBreaker(name='WithFallback', fallback_function=fallback)
-    cb.call(func)
+    decorated_func = cb.decorate(func)
+
+    decorated_func()
     fallback.assert_called_once_with()
 
 def test_circuitbreaker_should_not_call_function_if_open():
     fallback = Mock(return_value=True)
 
-    func = Mock(return_value=False)
+    func = Mock(return_value=False, __name__="Mock") # attribute __name__ required for 2.7 compat with functools.wraps
 
     CircuitBreaker.opened = lambda self: True
     
     cb = CircuitBreaker(name='WithFallback', fallback_function=fallback)
-    assert cb.call(func) == fallback.return_value
+    decorated_func = cb.decorate(func)
+
+    assert decorated_func() == fallback.return_value
     assert not func.called
     
 


### PR DESCRIPTION
Hello,

The objective of this PR is to add support for detecting errors in generator functions and coroutines functions.
Today, the following example is not caught by CircuitBreaker, after this PR it will be.

```python
@CircuitBreaker()
def foo():
    yield 1
    raise Exception
```

To achieve this behavior, I inspired myself from the source code of loguru catch https://loguru.readthedocs.io/en/stable/_modules/loguru/_logger.html#Logger.catch

Basically we *have* to create variants of the same function for try-catching normal function, generators and coroutines, simply adding `if,else` block in `call()` does not work.

To make each variant as small and DRY as possible, I chose to use a context manager for error detection.

I added a small functional test for generators as a POC/control, but I wanted your opinion on the implementation before I spend more time on testing.

What do you think ? :)