### PR TITLE
tests: Update for Python 3.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - "3.7"
   - "3.8"
   - "3.9"
+  - "3.10-dev"
 install: pip install tox-travis
 script: tox
 after_script:

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -1,6 +1,10 @@
 from time import sleep
 
-from mock.mock import patch, Mock
+try:
+    from unittest.mock import Mock, patch
+except ImportError:
+    from mock import Mock, patch
+
 from pytest import raises
 
 from circuitbreaker import CircuitBreaker, CircuitBreakerError, \
@@ -78,7 +82,7 @@ def test_threshold_hit_prevents_consequent_calls(mock_remote):
     with raises(CircuitBreakerError):
         circuit_threshold_1()
 
-    mock_remote.assert_called_once()
+    mock_remote.assert_called_once_with()
 
 
 @patch('test_functional.pseudo_remote_call', return_value=True)
@@ -241,4 +245,4 @@ def test_circuitbreaker_handles_generator_functions(mock_remote):
     with raises(CircuitBreakerError):
         list(circuit_generator_failure())
 
-    mock_remote.assert_called_once()
+    mock_remote.assert_called_once_with()

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1,9 +1,8 @@
 try:
-    from unittest.mock import Mock
+    from unittest.mock import Mock, patch
 except ImportError:
-    from mock import Mock
+    from mock import Mock, patch
 
-from mock.mock import patch
 from pytest import raises
 
 from circuitbreaker import CircuitBreaker, CircuitBreakerError, circuit
@@ -50,7 +49,7 @@ def test_circuitbreaker_should_call_fallback_function_if_open():
     func = Mock(return_value=False, __name__="Mock") # attribute __name__ required for 2.7 compat with functools.wraps
 
     CircuitBreaker.opened = lambda self: True
-    
+
     cb = CircuitBreaker(name='WithFallback', fallback_function=fallback)
     decorated_func = cb.decorate(func)
 
@@ -63,13 +62,13 @@ def test_circuitbreaker_should_not_call_function_if_open():
     func = Mock(return_value=False, __name__="Mock") # attribute __name__ required for 2.7 compat with functools.wraps
 
     CircuitBreaker.opened = lambda self: True
-    
+
     cb = CircuitBreaker(name='WithFallback', fallback_function=fallback)
     decorated_func = cb.decorate(func)
 
     assert decorated_func() == fallback.return_value
     assert not func.called
-    
+
 
 def mocked_function(*args, **kwargs):
     pass
@@ -86,7 +85,7 @@ def test_circuitbreaker_call_fallback_function_with_parameters():
     func_decorated('test2',test='test')
 
     # check args and kwargs are getting correctly to fallback function
-    
+
     fallback.assert_called_once_with('test2', test='test')
 
 @patch('circuitbreaker.CircuitBreaker.decorate')

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,9 @@ basepython = python3.8
 [testenv:py39]
 basepython = python3.9
 
+[testenv:py310]
+basepython = python3.10
+
 [testenv:flake8]
 basepython=python3
 deps=flake8


### PR DESCRIPTION
Update tests to import unittest.mock instead of mock if it is available.
Also add Python 3.10 to the tox file.

Signed-off-by: Major Hayden <major@mhtx.net>