### PR TITLE
Use a monotonic clock source

### DIFF
--- a/circuitbreaker.py
+++ b/circuitbreaker.py
@@ -5,9 +5,9 @@ from __future__ import print_function
 from __future__ import absolute_import
 
 from functools import wraps
-from datetime import datetime, timedelta
 from inspect import isgeneratorfunction
 from typing import AnyStr, Iterable
+from time import monotonic
 
 STATE_CLOSED = 'closed'
 STATE_OPEN = 'open'
@@ -34,7 +34,7 @@ class CircuitBreaker(object):
         self._fallback_function = fallback_function or self.FALLBACK_FUNCTION
         self._name = name
         self._state = STATE_CLOSED
-        self._opened = datetime.utcnow()
+        self._opened = monotonic()
 
     def __call__(self, wrapped):
         return self.decorate(wrapped)
@@ -109,7 +109,7 @@ class CircuitBreaker(object):
         self._failure_count += 1
         if self._failure_count >= self._failure_threshold:
             self._state = STATE_OPEN
-            self._opened = datetime.utcnow()
+            self._opened = monotonic()
 
     @property
     def state(self):
@@ -120,18 +120,18 @@ class CircuitBreaker(object):
     @property
     def open_until(self):
         """
-        The datetime, when the circuit breaker will try to recover
-        :return: datetime
+        The monotime when the circuit breaker will try to recover
+        :return: float
         """
-        return self._opened + timedelta(seconds=self._recovery_timeout)
+        return self._opened + self._recovery_timeout
 
     @property
     def open_remaining(self):
         """
         Number of seconds remaining, the circuit breaker stays in OPEN state
-        :return: int
+        :return: float
         """
-        return (self.open_until - datetime.utcnow()).total_seconds()
+        return self.open_until - monotonic()
 
     @property
     def failure_count(self):

--- a/circuitbreaker.py
+++ b/circuitbreaker.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 
 from functools import wraps
+from datetime import datetime, timedelta
 from inspect import isgeneratorfunction
 from typing import AnyStr, Iterable
 
@@ -124,18 +125,18 @@ class CircuitBreaker(object):
     @property
     def open_until(self):
         """
-        The monotime when the circuit breaker will try to recover
-        :return: float
+        The approximate datetime when the circuit breaker will try to recover
+        :return: datetime
         """
-        return self._opened + self._recovery_timeout
+        return datetime.utcnow() + timedelta(seconds=self.open_remaining)
 
     @property
     def open_remaining(self):
         """
         Number of seconds remaining, the circuit breaker stays in OPEN state
-        :return: float
+        :return: int
         """
-        return self.open_until - monotonic()
+        return int((self._opened + self._recovery_timeout) - monotonic())
 
     @property
     def failure_count(self):

--- a/circuitbreaker.py
+++ b/circuitbreaker.py
@@ -7,7 +7,11 @@ from __future__ import absolute_import
 from functools import wraps
 from inspect import isgeneratorfunction
 from typing import AnyStr, Iterable
-from time import monotonic
+
+try:
+  from time import monotonic
+except ImportError:
+  from monotonic import monotonic
 
 STATE_CLOSED = 'closed'
 STATE_OPEN = 'open'

--- a/circuitbreaker.py
+++ b/circuitbreaker.py
@@ -134,9 +134,9 @@ class CircuitBreaker(object):
     def open_remaining(self):
         """
         Number of seconds remaining, the circuit breaker stays in OPEN state
-        :return: int
+        :return: float
         """
-        return int((self._opened + self._recovery_timeout) - monotonic())
+        return (self._opened + self._recovery_timeout) - monotonic()
 
     @property
     def failure_count(self):

--- a/circuitbreaker.py
+++ b/circuitbreaker.py
@@ -8,6 +8,7 @@ from functools import wraps
 from datetime import datetime, timedelta
 from inspect import isgeneratorfunction
 from typing import AnyStr, Iterable
+from math import ceil, floor
 
 try:
   from time import monotonic
@@ -134,9 +135,10 @@ class CircuitBreaker(object):
     def open_remaining(self):
         """
         Number of seconds remaining, the circuit breaker stays in OPEN state
-        :return: float
+        :return: int
         """
-        return (self._opened + self._recovery_timeout) - monotonic()
+        remain = (self._opened + self._recovery_timeout) - monotonic()
+        return ceil(remain) if remain > 0 else floor(remain)
 
     @property
     def failure_count(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 typing; python_version < '3.5'
+monotonic; python_version < '3.0'


### PR DESCRIPTION
Using the wall clock to measure durations is vulnerable to changes in
the system clock causing misbehaviour - a clock accidentally set far in
the future and later reset could result in the circuit breaker remaining
open for a great deal longer than expected.

This slightly changes the API - open_until() now returns a monotonic
time corresponding to time.monotonic(), and open_remaining() now returns
a float.