### PR TITLE
Mark the mock dev requirement as only being required for Python before 3.3

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,4 @@
-mock
+mock; python_version < '3.3'
 pytest
 pytest-mock
 pytest-cov


### PR DESCRIPTION
The default mock used is unittest.mock, which is available since Python 3.3.

Fixes: commit 8d382799994fbdb75782979f84eac6cbfca2e8ed
See-also: https://mock.readthedocs.io/en/latest/
