### PR TITLE
Failure if predicate

### DIFF
--- a/circuitbreaker.py
+++ b/circuitbreaker.py
@@ -34,9 +34,10 @@ class CircuitBreaker(object):
                  failure_threshold=None,
                  recovery_timeout=None,
                  expected_exception=None,
-                 is_breaking_exception=None,
                  name=None,
-                 fallback_function=None):
+                 fallback_function=None,
+                 is_breaking_exception=None
+                 ):
         self._last_failure = None
         self._failure_count = 0
         self._failure_threshold = failure_threshold or self.FAILURE_THRESHOLD
@@ -247,9 +248,9 @@ def circuit(failure_threshold=None,
             recovery_timeout=None,
             expected_exception=None,
             name=None,
-            is_breaking_exception=None,
             fallback_function=None,
-            cls=CircuitBreaker):
+            cls=CircuitBreaker,
+            is_breaking_exception=None):
 
     # if the decorator is used without parameters, the
     # wrapped function is provided as first argument
@@ -260,6 +261,6 @@ def circuit(failure_threshold=None,
             failure_threshold=failure_threshold,
             recovery_timeout=recovery_timeout,
             expected_exception=expected_exception,
-            is_breaking_exception=None,
             name=name,
-            fallback_function=fallback_function)
+            fallback_function=fallback_function,
+            is_breaking_exception=None)

--- a/circuitbreaker.py
+++ b/circuitbreaker.py
@@ -40,18 +40,18 @@ class CircuitBreaker(object):
         """
         Construct a circuit breaker.
 
-            :param failure_threshold: break open after this many failures
-            :param recovery_timout: close after this many seconds
-            :param expected_exception: either an Exception type, iterable of exception types, or a predicate function.
-                      If an exception or iterable of exception types, a failure will be triggered when a thrown
-                      exception matches a type.
+        :param failure_threshold: break open after this many failures
+        :param recovery_timout: close after this many seconds
+        :param expected_exception: either an type of Exception, iterable of Exception types, or a predicate function.
+          If an Exception type or iterable of Exception types, a failure will be triggered when a thrown
+          exception matches a type.
 
-                      If this is a predicate function, it should have the signature (class, Exception) -> bool,
-                      where the args are the exception type and the exception value. Return value True
-                      indicates a failure in the underlying function.
+          If a predicate function, it will be called with the exception type and the exception value 
+          when an exception is thrown. It should have the signature (Type[Exception], Exception) -> bool.
+          Return value True indicates a failure in the underlying function.
 
-            :param name: name for this circuitbreaker
-            :param fallback_function: called when the circuit is opened
+        :param name: name for this circuitbreaker
+        :param fallback_function: called when the circuit is opened
 
            :return: Circuitbreaker instance
            :rtype: Circuitbreaker

--- a/circuitbreaker.py
+++ b/circuitbreaker.py
@@ -22,7 +22,7 @@ STATE_HALF_OPEN = 'half_open'
 def in_exception_list(*exc_types):
     """Build a predicate function that checks if an exception is a subtype from a list"""
     def matches_types(thrown_type, thrown_value):
-        return any(issubclass(thrown_type, et) for et in exc_types)
+        return issubclass(thrown_type, exc_types)
     return matches_types
 
 class CircuitBreaker(object):
@@ -81,7 +81,7 @@ class CircuitBreaker(object):
             else:
                 # iterable of Exceptions
                 assert not isinstance(failure_if, str) # paranoid guard against a mistake
-                self.is_failure = in_exception_list(failure_if)
+                self.is_failure = in_exception_list(*failure_if)
 
         self._fallback_function = fallback_function or self.FALLBACK_FUNCTION
         self._name = name

--- a/circuitbreaker.py
+++ b/circuitbreaker.py
@@ -33,6 +33,40 @@ def in_exception_list(*exc_types):
         return issubclass(thrown_type, exc_types)
     return matches_types
 
+def build_failure_predicate(expected_exception):
+    """ Build a failure predicate_function.
+          The returned function has the signature (Type[Exception], Exception) -> bool.
+          Return value True indicates a failure in the underlying function.
+
+        :param expected_exception: either an type of Exception, iterable of Exception types, or a predicate function.
+
+          If an Exception type or iterable of Exception types, the failure predicate will return True when a thrown exception type
+           matches one of the provided types.
+
+          If a predicate function, it will just be returned as is.
+
+         :return: callable (Type[Exception], Exception) -> bool
+    """
+
+    if isclass(expected_exception) and issubclass(expected_exception, Exception):
+        def check_exception(thrown_type, _):
+            return issubclass(thrown_type, expected_exception)
+        failure_predicate = check_exception
+    else:
+        try:
+             # Check for an iterable of Exception types
+            iter(expected_exception)
+
+            # guard against a surprise later
+            assert not isinstance(expected_exception, STRING_TYPES), "expected_exception cannot be a string. Did you mean name?"
+            failure_predicate = in_exception_list(*expected_exception)
+        except TypeError:
+            # not iterable. guess that it's a predicate function
+            assert callable(expected_exception) and not isclass(expected_exception), "expected_exception does not look like a predicate"
+            failure_predicate = expected_exception
+    return failure_predicate
+
+
 class CircuitBreaker(object):
     FAILURE_THRESHOLD = 5
     RECOVERY_TIMEOUT = 30
@@ -51,13 +85,6 @@ class CircuitBreaker(object):
         :param failure_threshold: break open after this many failures
         :param recovery_timeout: close after this many seconds
         :param expected_exception: either an type of Exception, iterable of Exception types, or a predicate function.
-          If an Exception type or iterable of Exception types, a failure will be triggered when a thrown
-          exception matches a type.
-
-          If a predicate function, it will be called with the exception type and the exception value 
-          when an exception is thrown. It should have the signature (Type[Exception], Exception) -> bool.
-          Return value True indicates a failure in the underlying function.
-
         :param name: name for this circuitbreaker
         :param fallback_function: called when the circuit is opened
 
@@ -69,26 +96,8 @@ class CircuitBreaker(object):
         self._failure_threshold = failure_threshold or self.FAILURE_THRESHOLD
         self._recovery_timeout = recovery_timeout or self.RECOVERY_TIMEOUT
 
-        # default to plain old Exception
-        expected_exception = expected_exception or Exception
-
         # auto-construct a failure predicate, depending on the type of the 'expected_exception' param
-        if isclass(expected_exception) and issubclass(expected_exception, Exception):
-            def check_exception(thrown_type, _):
-                return issubclass(thrown_type, expected_exception)
-            self.is_failure = check_exception
-        else:
-            try:
-                 # Check for an iterable of Exception types
-                iter(expected_exception)
-
-                # guard against a surprise later
-                assert not isinstance(expected_exception, STRING_TYPES), "expected_exception cannot be a string. Did you mean name?"
-                self.is_failure = in_exception_list(*expected_exception)
-            except TypeError:
-                # not iterable. guess that it's a predicate function
-                assert callable(expected_exception) and not isclass(expected_exception), "expected_exception does not look like a predicate"
-                self.is_failure = expected_exception
+        self.is_failure = build_failure_predicate(expected_exception or Exception)
 
         self._fallback_function = fallback_function or self.FALLBACK_FUNCTION
         self._name = name

--- a/circuitbreaker.py
+++ b/circuitbreaker.py
@@ -18,7 +18,7 @@ except ImportError:
 # Python2 vs Python3 strings
 try:
     basestring
-    STRING_TYPES = (basestring, unicode)
+    STRING_TYPES = (basestring, )
 except NameError:
     STRING_TYPES = (bytes, str)
 
@@ -29,7 +29,7 @@ STATE_HALF_OPEN = 'half_open'
 
 def in_exception_list(*exc_types):
     """Build a predicate function that checks if an exception is a subtype from a list"""
-    def matches_types(thrown_type, thrown_value):
+    def matches_types(thrown_type, _):
         return issubclass(thrown_type, exc_types)
     return matches_types
 
@@ -49,7 +49,7 @@ class CircuitBreaker(object):
         Construct a circuit breaker.
 
         :param failure_threshold: break open after this many failures
-        :param recovery_timout: close after this many seconds
+        :param recovery_timeout: close after this many seconds
         :param expected_exception: either an type of Exception, iterable of Exception types, or a predicate function.
           If an Exception type or iterable of Exception types, a failure will be triggered when a thrown
           exception matches a type.

--- a/circuitbreaker.py
+++ b/circuitbreaker.py
@@ -19,7 +19,7 @@ STATE_CLOSED = 'closed'
 STATE_OPEN = 'open'
 STATE_HALF_OPEN = 'half_open'
 
-def in_exception_list(exc_types):
+def in_exception_list(*exc_types):
     """Build a predicate function that checks if an exception is a subclass of a specified type"""
     def matches_types(thrown_type, thrown_value):
         return any(issubclass(thrown_type, et) for et in exc_types)
@@ -263,4 +263,4 @@ def circuit(failure_threshold=None,
             expected_exception=expected_exception,
             name=name,
             fallback_function=fallback_function,
-            is_breaking_exception=None)
+            is_breaking_exception=is_breaking_exception)

--- a/circuitbreaker.py
+++ b/circuitbreaker.py
@@ -41,14 +41,14 @@ class CircuitBreaker(object):
         Construct a circuit breaker.
 
             :param failure_threshold: break open after this many failures
-            :param recovery_timout: clase after this many seconds
+            :param recovery_timout: close after this many seconds
             :param failure_if: either an Exception type, iterable of exception types, or a predicate function.
-                      If an exception or list of exception types, a failure will be triggered when a thrown
+                      If an exception or iterable of exception types, a failure will be triggered when a thrown
                       exception matches a type.
 
                       If this is a predicate function, it should have the signature (class, Exception) -> bool,
                       where the args are the exception type and the exception value. Return value True
-                      indicates a breaker failure.
+                      indicates a failure in the underlying function.
 
             :param name: name for this circuitbreaker
             :param fallback_function: called when the circuit is opened
@@ -64,7 +64,7 @@ class CircuitBreaker(object):
         # default to plain old Exception
         failure_if = failure_if or Exception
 
-        # suto-construct a breaker predicate, depending on the type of the 'failure_if' param
+        # auto-construct a failure predicate, depending on the type of the 'failure_if' param
         if isclass(failure_if) and issubclass(failure_if, Exception):
             def check_exception(thrown_type, _):
                 return issubclass(thrown_type, failure_if)

--- a/circuitbreaker.py
+++ b/circuitbreaker.py
@@ -35,8 +35,7 @@ class CircuitBreaker(object):
                  recovery_timeout=None,
                  failure_if=None,
                  name=None,
-                 fallback_function=None,
-                 expected_exception=None
+                 fallback_function=None
                  ):
         """
         Construct a circuit breaker.
@@ -53,7 +52,6 @@ class CircuitBreaker(object):
 
             :param name: name for this circuitbreaker
             :param fallback_function: called when the circuit is opened
-            :param expected_exception: exception class. use failure_if instead. This is for backwards compatibility
 
            :return: Circuitbreaker instance
            :rtype: Circuitbreaker
@@ -63,15 +61,8 @@ class CircuitBreaker(object):
         self._failure_threshold = failure_threshold or self.FAILURE_THRESHOLD
         self._recovery_timeout = recovery_timeout or self.RECOVERY_TIMEOUT
 
-        # Support expected_exception for backwards compatibility
-        #  with code that uses kwargs. Deprecate the 'expected_exception' parameter
-        #  to simplfiy this code
-        assert bool(failure_if) ^ bool(expected_exception), "Only one of 'failure_if' or 'expected_exception' is allowed"
-        if expected_exception is not None:
-            failure_if = expected_exception
-
         # default to plain old Exception
-        failure_if = failure_if or Exception #
+        failure_if = failure_if or Exception
 
         # suto-construct a breaker predicate, depending on the type of the 'failure_if' param
         if isclass(failure_if) and issubclass(failure_if, Exception):

--- a/circuitbreaker.py
+++ b/circuitbreaker.py
@@ -20,7 +20,7 @@ STATE_OPEN = 'open'
 STATE_HALF_OPEN = 'half_open'
 
 def in_exception_list(*exc_types):
-    """Build a predicate function that checks if an exception is a subclass of a specified type"""
+    """Build a predicate function that checks if an exception is a subtype from a list"""
     def matches_types(thrown_type, thrown_value):
         return any(issubclass(thrown_type, et) for et in exc_types)
     return matches_types

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         'Operating System :: MacOS',
         'Operating System :: Unix',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 3',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ setup(
         'Operating System :: MacOS',
         'Operating System :: Unix',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 3',
     ]
 )

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -117,11 +117,11 @@ def test_circuit_decorator_with_args():
     assert breaker._name == "foobar"
     assert breaker._fallback_function == function_fallback
 
-def test_breaker_failure_if_with_predicate():
+def test_breaker_expected_exception_is_predicate():
     def is_four_foo(thrown_type, thrown_value):
         return thrown_value.val == 4
 
-    breaker_four = circuit(failure_if=is_four_foo)
+    breaker_four = circuit(expected_exception=is_four_foo)
 
     assert breaker_four.is_failure(FooError, FooError(4))
     assert not breaker_four.is_failure(FooError, FooError(2))
@@ -133,17 +133,17 @@ def test_breaker_default_constructor_traps_Exception():
     assert breaker.is_failure(FooError, FooError())
 
 
-def test_breaker_failure_if_with_custom_exception():
+def test_breaker_expected_exception_is_custom_exception():
 
-    breaker = circuit(failure_if=FooError)
+    breaker = circuit(expected_exception=FooError)
     assert breaker.is_failure(FooError, FooError())
     assert not breaker.is_failure(Exception, Exception())
 
-def test_breaker_constructor_failure_if_with_exception_list():
+def test_breaker_constructor_expected_exception_is_exception_list():
 
     class BarError(Exception): pass
 
-    breaker = circuit(failure_if=(FooError, BarError))
+    breaker = circuit(expected_exception=(FooError, BarError))
     assert breaker.is_failure(FooError, FooError())
     assert breaker.is_failure(BarError, BarError())
     assert not breaker.is_failure(Exception, Exception())

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -148,3 +148,15 @@ def test_breaker_constructor_expected_exception_is_exception_list():
     assert breaker.is_failure(BarError, BarError())
     assert not breaker.is_failure(Exception, Exception())
 
+def test_constructor_mistake_name_bytes():
+    with raises(AssertionError, match="expected_exception cannot be a string *"):
+        breaker = circuit(10, 20, b"foobar")
+
+def test_constructor_mistake_name_unicode():
+    with raises(AssertionError , match="expected_exception cannot be a string *"):
+        breaker = circuit(10, 20, u"foobar")
+
+def test_constructor_mistake_expected_exception():
+    class Widget: pass
+    with raises(AssertionError , match="expected_exception does not look like a predicate*"):
+        breaker = circuit(10, 20, expected_exception=Widget)

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -117,11 +117,11 @@ def test_circuit_decorator_with_args():
     assert breaker._name == "foobar"
     assert breaker._fallback_function == function_fallback
 
-def test_breaker_predicate_constructor():
+def test_breaker_failure_if_with_predicate():
     def is_four_foo(thrown_type, thrown_value):
         return thrown_value.val == 4
 
-    breaker_four = circuit(break_if=is_four_foo)
+    breaker_four = circuit(failure_if=is_four_foo)
 
     assert breaker_four.is_breaking_exception(FooError, FooError(4))
     assert not breaker_four.is_breaking_exception(FooError, FooError(2))
@@ -133,18 +133,18 @@ def test_breaker_default_constructor_traps_Exception():
     assert breaker.is_breaking_exception(FooError, FooError())
 
 
-def test_breaker_default_constructor_traps_FooError():
+def test_breaker_failure_if_with_custom_exception():
 
-    breaker = circuit(break_if=FooError)
-    assert not breaker.is_breaking_exception(Exception, Exception())
+    breaker = circuit(failure_if=FooError)
     assert breaker.is_breaking_exception(FooError, FooError())
+    assert not breaker.is_breaking_exception(Exception, Exception())
 
-def test_breaker_constructor_with_exception_list_predicat():
+def test_breaker_constructor_faliure_if_with_exception_list():
 
     class BarError(Exception): pass
 
-    breaker = circuit(break_if=(FooError, BarError))
-    assert not breaker.is_breaking_exception(Exception, Exception())
+    breaker = circuit(failure_if=(FooError, BarError))
     assert breaker.is_breaking_exception(FooError, FooError())
     assert breaker.is_breaking_exception(BarError, BarError())
+    assert not breaker.is_breaking_exception(Exception, Exception())
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -5,7 +5,7 @@ except ImportError:
 
 from pytest import raises
 
-from circuitbreaker import CircuitBreaker, CircuitBreakerError, circuit, in_exception_list
+from circuitbreaker import CircuitBreaker, CircuitBreakerError, circuit
 
 class FooError(Exception): 
     def __init__(self, val=None):

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -121,7 +121,7 @@ def test_breaker_predicate_constructor():
     def is_four_foo(thrown_type, thrown_value):
         return thrown_value.val == 4
 
-    breaker_four = circuit(is_breaking_exception=is_four_foo)
+    breaker_four = circuit(break_if=is_four_foo)
 
     assert breaker_four.is_breaking_exception(FooError, FooError(4))
     assert not breaker_four.is_breaking_exception(FooError, FooError(2))
@@ -135,7 +135,7 @@ def test_breaker_default_constructor_traps_Exception():
 
 def test_breaker_default_constructor_traps_FooError():
 
-    breaker = circuit(expected_exception=FooError)
+    breaker = circuit(break_if=FooError)
     assert not breaker.is_breaking_exception(Exception, Exception())
     assert breaker.is_breaking_exception(FooError, FooError())
 
@@ -143,7 +143,7 @@ def test_breaker_constructor_with_exception_list_predicat():
 
     class BarError(Exception): pass
 
-    breaker = circuit(is_breaking_exception=in_exception_list(FooError, BarError))
+    breaker = circuit(break_if=(FooError, BarError))
     assert not breaker.is_breaking_exception(Exception, Exception())
     assert breaker.is_breaking_exception(FooError, FooError())
     assert breaker.is_breaking_exception(BarError, BarError())

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -103,9 +103,10 @@ def test_circuit_decorator_with_args():
     def function_fallback():
         return True
 
+
     breaker = circuit(10, 20, KeyError, 'foobar', function_fallback)
 
-    assert breaker._expected_exception == KeyError
+    assert breaker.is_breaking_exception(KeyError, KeyError("I am a bad key"))
     assert breaker._failure_threshold == 10
     assert breaker._recovery_timeout == 20
     assert breaker._name == "foobar"

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -99,17 +99,15 @@ def test_circuit_decorator_without_args(circuitbreaker_mock):
     circuitbreaker_mock.assert_called_once_with(function)
 
 
-@patch('circuitbreaker.CircuitBreaker.__init__')
-def test_circuit_decorator_with_args(circuitbreaker_mock):
+def test_circuit_decorator_with_args():
     def function_fallback():
         return True
 
-    circuitbreaker_mock.return_value = None
-    circuit(10, 20, KeyError, 'foobar', function_fallback)
-    circuitbreaker_mock.assert_called_once_with(
-        expected_exception=KeyError,
-        failure_threshold=10,
-        recovery_timeout=20,
-        name='foobar',
-        fallback_function=function_fallback
-    )
+    breaker = circuit(10, 20, KeyError, 'foobar', function_fallback)
+
+    assert breaker._expected_exception == KeyError
+    assert breaker._failure_threshold == 10
+    assert breaker._recovery_timeout == 20
+    assert breaker._name == "foobar"
+    assert breaker._fallback_function == function_fallback
+

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -109,9 +109,9 @@ def test_circuit_decorator_with_args():
 
     breaker = circuit(10, 20, KeyError, 'foobar', function_fallback)
 
-    assert breaker.is_breaking_exception(KeyError, None)
-    assert not breaker.is_breaking_exception(Exception, None)
-    assert not breaker.is_breaking_exception(FooError, None)
+    assert breaker.is_failure(KeyError, None)
+    assert not breaker.is_failure(Exception, None)
+    assert not breaker.is_failure(FooError, None)
     assert breaker._failure_threshold == 10
     assert breaker._recovery_timeout == 20
     assert breaker._name == "foobar"
@@ -123,28 +123,28 @@ def test_breaker_failure_if_with_predicate():
 
     breaker_four = circuit(failure_if=is_four_foo)
 
-    assert breaker_four.is_breaking_exception(FooError, FooError(4))
-    assert not breaker_four.is_breaking_exception(FooError, FooError(2))
+    assert breaker_four.is_failure(FooError, FooError(4))
+    assert not breaker_four.is_failure(FooError, FooError(2))
 
 def test_breaker_default_constructor_traps_Exception():
 
     breaker = circuit()
-    assert breaker.is_breaking_exception(Exception, Exception())
-    assert breaker.is_breaking_exception(FooError, FooError())
+    assert breaker.is_failure(Exception, Exception())
+    assert breaker.is_failure(FooError, FooError())
 
 
 def test_breaker_failure_if_with_custom_exception():
 
     breaker = circuit(failure_if=FooError)
-    assert breaker.is_breaking_exception(FooError, FooError())
-    assert not breaker.is_breaking_exception(Exception, Exception())
+    assert breaker.is_failure(FooError, FooError())
+    assert not breaker.is_failure(Exception, Exception())
 
 def test_breaker_constructor_faliure_if_with_exception_list():
 
     class BarError(Exception): pass
 
     breaker = circuit(failure_if=(FooError, BarError))
-    assert breaker.is_breaking_exception(FooError, FooError())
-    assert breaker.is_breaking_exception(BarError, BarError())
-    assert not breaker.is_breaking_exception(Exception, Exception())
+    assert breaker.is_failure(FooError, FooError())
+    assert breaker.is_failure(BarError, BarError())
+    assert not breaker.is_failure(Exception, Exception())
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -139,7 +139,7 @@ def test_breaker_failure_if_with_custom_exception():
     assert breaker.is_failure(FooError, FooError())
     assert not breaker.is_failure(Exception, Exception())
 
-def test_breaker_constructor_faliure_if_with_exception_list():
+def test_breaker_constructor_failure_if_with_exception_list():
 
     class BarError(Exception): pass
 


### PR DESCRIPTION
Implements feature request for https://github.com/fabfuel/circuitbreaker/issues/38.

This adds support for:
* failling on a single Exception type
* failing on a list of Exception types
* failing with a custom predicate function for arbitrary logic

It will deprecate:
* 'expected_exception' is replaced by 'failure_if'. Clients will only be affected if they use that parameter as a kwarg
* Python2 support. There are some trivial changes that only work in Python3.