### PR TITLE
Replace deprecated `datetime.utcnow`

### DIFF
--- a/circuitbreaker.py
+++ b/circuitbreaker.py
@@ -1,5 +1,5 @@
 from asyncio import iscoroutinefunction
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from functools import wraps
 from inspect import isgeneratorfunction, isasyncgenfunction, isclass
 from math import ceil, floor
@@ -245,7 +245,7 @@ class CircuitBreaker(object):
         The approximate datetime when the circuit breaker will try to recover
         :return: datetime
         """
-        return datetime.utcnow() + timedelta(seconds=self.open_remaining)
+        return datetime.now(timezone.utc) + timedelta(seconds=self.open_remaining)
 
     @property
     def open_remaining(self):


### PR DESCRIPTION
https://docs.python.org/3/whatsnew/3.12.html#deprecated

> [`datetime.datetime`](https://docs.python.org/3/library/datetime.html#datetime.datetime)’s [`utcnow()`](https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow) and [`utcfromtimestamp()`](https://docs.python.org/3/library/datetime.html#datetime.datetime.utcfromtimestamp) are deprecated and will be removed in a future version. Instead, use timezone-aware objects to represent datetimes in UTC: respectively, call [`now()`](https://docs.python.org/3/library/datetime.html#datetime.datetime.now) and [`fromtimestamp()`](https://docs.python.org/3/library/datetime.html#datetime.datetime.fromtimestamp) with the `tz` parameter set to [`datetime.UTC`](https://docs.python.org/3/library/datetime.html#datetime.UTC).