### PR TITLE
Make reset explicit and public

### DIFF
--- a/circuitbreaker.py
+++ b/circuitbreaker.py
@@ -116,7 +116,7 @@ class CircuitBreaker(object):
             self._last_failure = exc_value
             self.__call_failed()
         else:
-            self.__call_succeeded()
+            self.reset()
         return False  # return False to raise exception if any
 
     def decorate(self, function):
@@ -216,9 +216,9 @@ class CircuitBreaker(object):
             async for el in func(*args, **kwargs):
                 yield el
 
-    def __call_succeeded(self):
+    def reset(self):
         """
-        Close circuit after successful execution and reset failure count
+        Close circuit and reset failure count
         """
         self._state = STATE_CLOSED
         self._last_failure = None


### PR DESCRIPTION
Fixed issue [#64](https://github.com/fabfuel/circuitbreaker/issues/64)

The **__call_succeeded** method already did a reset, so i decided just to rename it.

I could do something like this instead:

```python
def __call_succeeded(self):
    self.reset()

def reset(self):
    self._state = STATE_CLOSED
    self._last_failure = None
    self._failure_count = 0
```

But i thought there is no point, since **__call_succeeded** is only called in one place.

And, anyway, there is issue [#60](https://github.com/fabfuel/circuitbreaker/issues/60) that ideally should bring callbacks on state change. So there is no point to keep **__call_succeeded**.