### PR TITLE
Fix error when calling str(cb) on unnamed CircuitBreaker

### DIFF
--- a/circuitbreaker.py
+++ b/circuitbreaker.py
@@ -281,7 +281,7 @@ class CircuitBreaker(object):
         return self._fallback_function
 
     def __str__(self, *args, **kwargs):
-        return self._name
+        return self.name or 'unnamed_CircuitBreaker'
 
 
 class CircuitBreakerError(Exception):

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -34,6 +34,11 @@ def test_circuitbreaker__str__():
     assert str(cb) == 'Foobar'
 
 
+def test_circuitbreaker_unnamed__str__():
+    cb = CircuitBreaker()
+    assert str(cb) == 'unnamed_CircuitBreaker'
+
+
 def test_circuitbreaker_error__str__():
     cb = CircuitBreaker(name='Foobar')
     cb._last_failure = Exception()


### PR DESCRIPTION
fix #66 - __str__ on unnamed circuit breaker now returns `unnamed_CircuitBreaker` instead of throwing `TypeError`